### PR TITLE
Revert the change to check for valid email accounts on android

### DIFF
--- a/src/android/EmailComposerImpl.java
+++ b/src/android/EmailComposerImpl.java
@@ -560,17 +560,11 @@ public class EmailComposerImpl {
         AccountManager am  = AccountManager.get(ctx);
 
         try {
-            for (Account account : am.getAccounts()) {
-                if (account.type.endsWith("mail")) {
-                    return true;
-                }
-            }
+            return am.getAccounts().length > 0;
         } catch (Exception e) {
             Log.e(LOG_TAG, "Missing GET_ACCOUNTS permission.");
             return true;
         }
-
-        return false;
     }
 
     /**


### PR DESCRIPTION
Since it does not work for gmail, which is arguably the most popular mail
program on android.
